### PR TITLE
Introduces and recommends the byteorder crate

### DIFF
--- a/rusthotp/Cargo.toml
+++ b/rusthotp/Cargo.toml
@@ -16,6 +16,9 @@ travis-ci = { repository = "nulogy/RusTOTP" }
 [dependencies]
 hmac-sha1 = "^0.1"
 
+[dev-dependencies]
+byteorder = "1"
+
 [profile.dev]
 debug = true
 

--- a/rusthotp/src/lib.rs
+++ b/rusthotp/src/lib.rs
@@ -18,24 +18,24 @@ use std::fmt;
 ///
 /// # Examples
 ///
-/// To generate an HOTP value between 0 and 10^6 - 1, given the shared secret ASCII key `"Hello world!"` and current
-/// counter `0`:
+/// To generate a six-digit HOTP value (i.e. between 0 and 10^6 - 1), given the shared secret ASCII key `"Hello world!"`
+/// and current counter `0`:
 ///
 /// ```
-/// let six_digit_result = rusthotp::hotp(6, "Hello world!".as_bytes(), &[0; 8]); assert_eq!(format!("{}",
-/// six_digit_result), "124111");
+/// let six_digit_result = rusthotp::hotp(6, "Hello world!".as_bytes(), &[0; 8]);
+/// assert_eq!(format!("{}", six_digit_result), "124111");
 /// ```
 ///
-/// To generate an HOTP value between 0 and 10^8 - 1, given the shared secret ASCII key `"12345678901234567890"` and
-/// current counter `1`:
+/// To generate an eight-digit HOTP value (i.e. between 0 and 10^8 - 1), given the shared secret ASCII key
+/// `"12345678901234567890"` and current counter `1`:
 ///
 /// ```
 /// let eight_digit_result = rusthotp::hotp(8, "12345678901234567890".as_bytes(), &[0, 0, 0, 0, 0, 0, 0, 1]);
 /// assert_eq!(format!("{}", eight_digit_result), "94287082");
 /// ```
 ///
-/// To generate an HOTP value between 0 and 10^6 - 1, given the shared secret ASCII key "Hello world!" and the unix
-/// timestamp 1493006116 as the counter:
+/// To generate a six-digit HOTP value given the shared secret ASCII key "Hello world!" and the unix timestamp
+/// 1493006116 as the counter:
 ///
 /// ```
 /// # extern crate byteorder;

--- a/rusthotp/src/lib.rs
+++ b/rusthotp/src/lib.rs
@@ -2,34 +2,53 @@ extern crate hmacsha1;
 
 use std::fmt;
 
-/// This implementation of HMAC-Based One Time Passwords proceeds in three
-/// stages, as per [RFC 4226](https://www.ietf.org/rfc/rfc4226.txt):
+/// This implementation of HMAC-Based One Time Passwords proceeds in three stages, as per [RFC
+/// 4226](https://www.ietf.org/rfc/rfc4226.txt):
 ///
-/// 1. Generate an HMAC-SHA-1 value given a shared secret `key` and a
-/// moving factor `counter` that *should* change on every use
-/// 2. Extraction of a 4-byte value from the SHA-1 digest
-/// 3. Deriving a final HOTP value between 0 and
-/// 10^{`desired_code_length`}-1 from the 4-byte value extracted
-/// in the last step.
+/// 1. Generate an HMAC-SHA-1 value given a shared secret `key` and a moving factor `counter` that *should* change on
+///    every use
+/// 2. Extraction of an indexing offset by reading the 4 low-order bits of the last byte of the SHA-1 digest
+/// 3. Extraction of a 4-byte value from the SHA-1 digest, starting at the index offset determined by the previous step
+/// 4. Deriving a final HOTP value between 0 and 10^{`desired_code_length`} -1 from the 4-byte value extracted in the
+///    previous step.
 ///
-/// Note that it is the responsibility of the caller to increment the counter accordingly per invocation.
+/// Note that it is the responsibility of the caller to increment the counter accordingly per invocation. Consider the
+/// use of the [byteorder crate](https://crates.io/crates/byteorder) if you need to convert from a numeric type into the
+/// array of 8 bytes that are expected by `hotp()`.
 ///
 /// # Examples
 ///
-/// To generate a six-digit HOTP value between 0 and 10^6 - 1, given the shared
-/// secret ASCII key `"Hello world!"` and current counter `0`:
+/// To generate an HOTP value between 0 and 10^6 - 1, given the shared secret ASCII key `"Hello world!"` and current
+/// counter `0`:
 ///
 /// ```
-/// let six_digit_result = rusthotp::hotp(6, "Hello world!".as_bytes(), &[0; 8]);
-/// assert_eq!(format!("{}", six_digit_result), "124111");
+/// let six_digit_result = rusthotp::hotp(6, "Hello world!".as_bytes(), &[0; 8]); assert_eq!(format!("{}",
+/// six_digit_result), "124111");
 /// ```
 ///
-/// To generate an eight-digit HOTP value between 0 and 10^8 - 1, given the shared
-/// secret ASCII key `"12345678901234567890"` and current counter `1`:
+/// To generate an HOTP value between 0 and 10^8 - 1, given the shared secret ASCII key `"12345678901234567890"` and
+/// current counter `1`:
 ///
 /// ```
 /// let eight_digit_result = rusthotp::hotp(8, "12345678901234567890".as_bytes(), &[0, 0, 0, 0, 0, 0, 0, 1]);
 /// assert_eq!(format!("{}", eight_digit_result), "94287082");
+/// ```
+///
+/// To generate an HOTP value between 0 and 10^6 - 1, given the shared secret ASCII key "Hello world!" and the unix
+/// timestamp 1493006116 as the counter:
+///
+/// ```
+/// # extern crate byteorder;
+/// # extern crate rusthotp;
+/// # fn main() {
+/// use byteorder::{BigEndian, ByteOrder};
+/// let timestamp : i64 = 1493006116;
+/// let mut unpacked_timestamp = [0; 8];
+/// BigEndian::write_i64(&mut unpacked_timestamp, timestamp);
+/// let result = rusthotp::hotp(6, "Hello world!".as_bytes(), &unpacked_timestamp);
+///
+/// assert_eq!(format!("{}", result), "106286");
+/// # }
 /// ```
 
 

--- a/rusthotp/tests/test_main.rs
+++ b/rusthotp/tests/test_main.rs
@@ -9,7 +9,6 @@ pub fn format_hex(s: &[u8]) -> String {
     format!("0x{}", human_representation.join(""))
 }
 
-
 #[test]
 fn hotp_conforms_to_example_1_given_in_rfc6238() {
     let key = "12345678901234567890".as_bytes();

--- a/rustotp/Cargo.toml
+++ b/rustotp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustotp"
-version = "0.2.0"
+version = "0.1.0"
 authors = [
   "Ryan De Villa <ryand@nulogy.com>",
   "Justin Fitzsimmons <justinf@nulogy.com>"

--- a/rustotp/Cargo.toml
+++ b/rustotp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustotp"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
   "Ryan De Villa <ryand@nulogy.com>",
   "Justin Fitzsimmons <justinf@nulogy.com>"
@@ -14,7 +14,8 @@ keywords = ["totp", "rfc6238"]
 travis-ci = { repository = "nulogy/RusTOTP" }
 
 [dependencies]
-rusthotp = { version = "0.1.0" }
+rusthotp = "0.1.0"
+byteorder = "1"
 
 [profile.dev]
 debug = true

--- a/rustotp/src/lib.rs
+++ b/rustotp/src/lib.rs
@@ -1,6 +1,8 @@
 extern crate rusthotp;
+use rusthotp::{HotpOutput, hotp};
 
-use rusthotp::{ HotpOutput, hotp };
+extern crate byteorder;
+use byteorder::{BigEndian, ByteOrder};
 
 /// Implements the Time-Based One-Time Password algorithm described in [RFC
 /// 6238](https://tools.ietf.org/html/rfc6238),
@@ -26,16 +28,11 @@ use rusthotp::{ HotpOutput, hotp };
 /// let eight_digit_result = rustotp::totp(8, 30, "12345678901234567890".as_bytes(), 59);
 /// assert_eq!(format!("{}", eight_digit_result), "94287082");
 /// ```
-pub fn totp(desired_code_length: usize, timestep: i64, key: &[u8], time: i64) -> HotpOutput {
-    let t = time / timestep;
-    hotp(desired_code_length, key, &to_bytes(t))
-}
 
-fn to_bytes(x: i64) -> [u8; 8] {
-    let mut temp = [0u8; 8];
-    for byte_index in 0..8 {
-        let shift_amount: usize = 8 * (7 - byte_index);
-        temp[byte_index] = (x >> shift_amount) as u8;
-    }
-    temp
+pub fn totp(desired_code_length: usize, timestep: i64, key: &[u8], time: i64) -> HotpOutput {
+    let counter = time / timestep;
+    let mut unpacked_counter = [0; 8];
+    BigEndian::write_i64(&mut unpacked_counter, counter);
+
+    hotp(desired_code_length, key, &unpacked_counter)
 }


### PR DESCRIPTION
Better to use a mature crate instead of using a handrolled bitshifting function for transformation of numeric types into byte arrays.